### PR TITLE
feat(auth-manager): added token generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16408,6 +16408,14 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
+    "node_modules/jose": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.0.tgz",
+      "integrity": "sha512-H+RVqxA6apaJ0rcQYupKYhos7uosAiF42gUcWZiwhICWMphDULFj/CRr1R0tV/JCv9DEeJaSyYYpc9luHHNT4g==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -25665,6 +25673,7 @@
         "express": "^4.18.2",
         "express-openapi-validator": "^5.0.3",
         "http-status-codes": "^2.2.0",
+        "jose": "^5.1.0",
         "pg": "^8.10.0",
         "reflect-metadata": "^0.1.13",
         "tsyringe": "^4.7.0",
@@ -33806,6 +33815,7 @@
         "express-openapi-validator": "^5.0.3",
         "http-status-codes": "^2.2.0",
         "jest-extended": "^3.2.4",
+        "jose": "^5.1.0",
         "pg": "^8.10.0",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^4.4.0",
@@ -38580,6 +38590,11 @@
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "jose": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.1.0.tgz",
+      "integrity": "sha512-H+RVqxA6apaJ0rcQYupKYhos7uosAiF42gUcWZiwhICWMphDULFj/CRr1R0tV/JCv9DEeJaSyYYpc9luHHNT4g=="
     },
     "joycon": {
       "version": "3.1.1",

--- a/packages/auth-manager/README.md
+++ b/packages/auth-manager/README.md
@@ -1,11 +1,6 @@
 # `auth-manager`
 
-> TODO: description
+## Note about tokens and connections
 
-## Usage
-
-```
-const authManager = require('auth-manager');
-
-// TODO: DEMONSTRATE API
-```
+When creating or updating a connection, a token will be generated automatically based on the private key.
+If for any reason the token generation failed, or no private key existed, the token field will be an empty string, and the reason will be logged.

--- a/packages/auth-manager/helm/values.yaml
+++ b/packages/auth-manager/helm/values.yaml
@@ -44,7 +44,7 @@ dbConfig:
   database: auth-manager
   # port: 5432
   externalSecretName: ''
-  useExternalSecret: false  
+  useExternalSecret: false
   sslAuth:
     enabled: false
     secretName: secret-name

--- a/packages/auth-manager/openapi3.yaml
+++ b/packages/auth-manager/openapi3.yaml
@@ -248,6 +248,12 @@ paths:
       summary: creates a new connection or updates it based on the version
       tags:
         - connection
+      parameters:
+        - in: query
+          name: ignoreTokenErrors
+          schema:
+            type: boolean
+            default: false
       requestBody:
         required: true
         content:

--- a/packages/auth-manager/openapi3.yaml
+++ b/packages/auth-manager/openapi3.yaml
@@ -250,7 +250,7 @@ paths:
         - connection
       parameters:
         - in: query
-          name: ignoreTokenErrors
+          name: shouldIgnoreTokenErrors
           schema:
             type: boolean
             default: false

--- a/packages/auth-manager/package.json
+++ b/packages/auth-manager/package.json
@@ -54,6 +54,7 @@
     "express": "^4.18.2",
     "express-openapi-validator": "^5.0.3",
     "http-status-codes": "^2.2.0",
+    "jose": "^5.1.0",
     "pg": "^8.10.0",
     "reflect-metadata": "^0.1.13",
     "tsyringe": "^4.7.0",

--- a/packages/auth-manager/src/common/constants.ts
+++ b/packages/auth-manager/src/common/constants.ts
@@ -5,6 +5,8 @@ export const DEFAULT_SERVER_PORT = 80;
 
 export const DB_CONNECTION_TIMEOUT = 5000;
 
+export const TOKENS_ISSUER = 'mapcolonies-token-cli';
+
 export const IGNORED_OUTGOING_TRACE_ROUTES = [/^.*\/v1\/metrics.*$/];
 export const IGNORED_INCOMING_TRACE_ROUTES = [/^.*\/docs.*$/];
 
@@ -21,5 +23,5 @@ export const SERVICES = {
   ASSET_REPOSITORY: Symbol('ASSET_REPO'),
   CONNECTION_REPOSITORY: Symbol('CONNECTION_REPO'),
   BUNDLE_REPOSITORY: Symbol('BUNDLE_REPO'),
-};
+} satisfies Record<string, symbol>;
 /* eslint-enable @typescript-eslint/naming-convention */

--- a/packages/auth-manager/src/common/crypto.ts
+++ b/packages/auth-manager/src/common/crypto.ts
@@ -1,0 +1,19 @@
+import { importJWK, JWK, SignJWT } from 'jose';
+import { TOKENS_ISSUER } from './constants';
+
+/**
+ * Generates a JWT token using the provided private key, client, kid, and expiration time.
+ * @param privateKey - The private key to use for signing the token.
+ * @param client - The client for whom the token is being generated.
+ * @param kid - The key ID to use in the token header.
+ * @param expirationTime - The expiration time for the token.
+ * @returns A Promise that resolves to the generated JWT token.
+ */
+export const generateToken = async (privateKey: JWK, client: string, kid?: string, expirationTime?: string): Promise<string> => {
+  const jwt = new SignJWT().setIssuedAt().setProtectedHeader({ alg: 'RS256', kid }).setSubject(client).setIssuer(TOKENS_ISSUER);
+  if (expirationTime !== undefined) {
+    jwt.setExpirationTime(expirationTime);
+  }
+  const key = await importJWK(privateKey);
+  return jwt.sign(key);
+};

--- a/packages/auth-manager/src/connection/controllers/connectionController.ts
+++ b/packages/auth-manager/src/connection/controllers/connectionController.ts
@@ -20,7 +20,7 @@ type EnvConnectionPathParams = {
   environment: Environment;
 } & ConnectionNamePathParams;
 
-type UpsertConnectionHandler = RequestHandler<undefined, IConnection, IConnection, { ignoreTokenErrors?: boolean }>;
+type UpsertConnectionHandler = RequestHandler<undefined, IConnection, IConnection, { shouldIgnoreTokenErrors?: boolean }>;
 type GetConnectionsHandler = RequestHandler<undefined, IConnection[], undefined, ConnectionSearchParams>;
 type GetNamedConnectionsHandler = RequestHandler<ConnectionNamePathParams, IConnection[]>;
 type GetNamedEnvConnectionsHandler = RequestHandler<EnvConnectionPathParams, IConnection[]>;
@@ -82,7 +82,7 @@ export class ConnectionController {
     this.logger.debug('executing #upsertConnection handler');
 
     try {
-      const createdConnection = await this.manager.upsertConnection(req.body, req.query.ignoreTokenErrors);
+      const createdConnection = await this.manager.upsertConnection(req.body, req.query.shouldIgnoreTokenErrors);
 
       const returnStatus = createdConnection.version === 1 ? httpStatus.CREATED : httpStatus.OK;
       return res.status(returnStatus).json(createdConnection);

--- a/packages/auth-manager/src/connection/models/connectionManager.ts
+++ b/packages/auth-manager/src/connection/models/connectionManager.ts
@@ -10,6 +10,7 @@ import { DomainNotFoundError } from '../../domain/models/errors';
 import { ConnectionRepository } from '../DAL/connectionRepository';
 import { KeyRepository } from '../../key/DAL/keyRepository';
 import { generateToken } from '../../common/crypto';
+import { KeyNotFoundError } from '../../key/models/errors';
 import { ConnectionSearchParams } from './connection';
 import { ConnectionVersionMismatchError, ConnectionNotFoundError } from './errors';
 
@@ -50,7 +51,7 @@ export class ConnectionManager {
     return connection;
   }
 
-  public async upsertConnection(connection: IConnection): Promise<IConnection> {
+  public async upsertConnection(connection: IConnection, ignoreTokenErrors = false): Promise<IConnection> {
     this.logger.info({ msg: 'upserting connection', connection: { environment: connection.environment, version: connection.version } });
     return this.connectionRepository.manager.transaction(async (transactionManager) => {
       const connectionRepo = transactionManager.withRepository(this.connectionRepository);
@@ -68,7 +69,7 @@ export class ConnectionManager {
         throw new DomainNotFoundError(`the following domains do not exist: ${notExistingDomains.join(', ')}`);
       }
 
-      connection.token = await this.handleToken(connection, this.keyRepository);
+      connection.token = await this.handleToken(connection, transactionManager.withRepository(this.keyRepository), !ignoreTokenErrors);
 
       const maxVersion = await connectionRepo.getMaxVersionWithLock(connection.name, connection.environment);
 
@@ -96,7 +97,7 @@ export class ConnectionManager {
     });
   }
 
-  private async handleToken(connection: IConnection, transactionKeyRepo: KeyRepository): Promise<string> {
+  private async handleToken(connection: IConnection, transactionKeyRepo: KeyRepository, throwOnError?: boolean): Promise<string> {
     if (connection.token !== '') {
       return connection.token;
     }
@@ -108,6 +109,9 @@ export class ConnectionManager {
         msg: 'no private key found for connection, could not create token',
         connection: { name: connection.name, environment: connection.environment },
       });
+      if (throwOnError === true) {
+        throw new KeyNotFoundError('no private key found for connection, could not create token');
+      }
       return '';
     }
 
@@ -115,6 +119,9 @@ export class ConnectionManager {
       return await generateToken(key.privateKey as JWK, connection.name, key.privateKey.kid);
     } catch (error) {
       this.logger.error({ msg: 'could not generate token', error });
+      if (throwOnError === true) {
+        throw error;
+      }
       return '';
     }
   }

--- a/packages/auth-manager/tests/integration/connection/connection.spec.ts
+++ b/packages/auth-manager/tests/integration/connection/connection.spec.ts
@@ -5,7 +5,7 @@ import httpStatusCodes from 'http-status-codes';
 import { DependencyContainer } from 'tsyringe';
 import 'jest-openapi';
 import { DataSource } from 'typeorm';
-import { Client, Connection, Domain, Environment, IConnection } from '@map-colonies/auth-core';
+import { Client, Connection, Domain, Environment, IConnection, Key } from '@map-colonies/auth-core';
 import { faker } from '@faker-js/faker';
 import { getApp } from '../../../src/app';
 import { SERVICES } from '../../../src/common/constants';
@@ -13,9 +13,10 @@ import { ConnectionRepository } from '../../../src/connection/DAL/connectionRepo
 import { getFakeConnection, getFakeIConnection } from '../../utils/connection';
 import { DomainRepository } from '../../../src/domain/DAL/domainRepository';
 import { getFakeClient } from '../../utils/client';
+import { getRealKeys } from '../../utils/key';
 import { ConnectionRequestSender } from './helpers/requestSender';
 
-describe('client', function () {
+describe('connection', function () {
   let requestSender: ConnectionRequestSender;
   let depContainer: DependencyContainer;
   const clients = [getFakeClient(false), getFakeClient(false)];
@@ -89,6 +90,7 @@ describe('client', function () {
         expect(res).toHaveProperty('status', httpStatusCodes.CREATED);
         expect(res).toSatisfyApiSpec();
         expect(res.body).toMatchObject(connection);
+        expect(res.body).toHaveProperty('token', connection.token);
       });
 
       it('should return 200 status code and the updated connection', async function () {
@@ -105,6 +107,43 @@ describe('client', function () {
         expect(res).toHaveProperty('status', httpStatusCodes.OK);
         expect(res).toSatisfyApiSpec();
         expect(res.body).toMatchObject({ ...connection, version: 2 });
+      });
+
+      it('should not generate a token and return an empty string if no token is supplied and no private key is available', async function () {
+        const client = getFakeClient(false);
+        const connection = getFakeIConnection();
+        connection.name = client.name;
+        connection.token = '';
+        await depContainer.resolve(DataSource).getRepository(Client).save(client);
+
+        const res = await requestSender.upsertConnection(connection);
+
+        delete connection.createdAt;
+
+        expect(res).toHaveProperty('status', httpStatusCodes.CREATED);
+        expect(res).toSatisfyApiSpec();
+        expect(res.body).toHaveProperty('token', '');
+      });
+
+      it('should generate a token if no token is supplied and private key is available', async function () {
+        const client = getFakeClient(false);
+        const connection = getFakeIConnection();
+        const keys = getRealKeys();
+        connection.name = client.name;
+        connection.environment = Environment.STAGE;
+        await depContainer.resolve(DataSource).getRepository(Client).save(client);
+        await depContainer.resolve(DataSource).getRepository(Connection).save(connection);
+        const keyRepo = depContainer.resolve(DataSource).getRepository(Key);
+        await keyRepo.clear();
+        await keyRepo.save({ environment: connection.environment, version: 1, privateKey: keys[0], publicKey: keys[1] });
+
+        delete connection.createdAt;
+
+        const res: { status: number; body: { token: string } } = await requestSender.upsertConnection({ ...connection, token: '' });
+
+        expect(res).toHaveProperty('status', httpStatusCodes.OK);
+        expect(res).toSatisfyApiSpec();
+        expect(res.body.token).not.toBeEmpty();
       });
     });
 

--- a/packages/auth-manager/tests/integration/connection/connection.spec.ts
+++ b/packages/auth-manager/tests/integration/connection/connection.spec.ts
@@ -118,7 +118,6 @@ describe('connection', function () {
         await depContainer.resolve(DataSource).getRepository(Client).save(client);
 
         const res = await requestSender.upsertConnection(connection, true);
-
         delete connection.createdAt;
 
         expect(res).toHaveProperty('status', httpStatusCodes.CREATED);

--- a/packages/auth-manager/tests/integration/connection/helpers/requestSender.ts
+++ b/packages/auth-manager/tests/integration/connection/helpers/requestSender.ts
@@ -25,11 +25,11 @@ export class ConnectionRequestSender {
     return supertest.agent(this.app).get(`/client/${clientName}/connection/${environment}/${version}`).set('Content-Type', 'application/json');
   }
 
-  public async upsertConnection(connection: IConnection, ignoreTokenErrors = false): Promise<supertest.Response> {
+  public async upsertConnection(connection: IConnection, shouldIgnoreTokenErrors = false): Promise<supertest.Response> {
     return supertest
       .agent(this.app)
       .post('/connection')
-      .query({ ignoreTokenErrors })
+      .query({ shouldIgnoreTokenErrors })
       .set('Content-Type', 'application/json')
       .send(connection as object);
   }

--- a/packages/auth-manager/tests/integration/connection/helpers/requestSender.ts
+++ b/packages/auth-manager/tests/integration/connection/helpers/requestSender.ts
@@ -25,10 +25,11 @@ export class ConnectionRequestSender {
     return supertest.agent(this.app).get(`/client/${clientName}/connection/${environment}/${version}`).set('Content-Type', 'application/json');
   }
 
-  public async upsertConnection(connection: IConnection): Promise<supertest.Response> {
+  public async upsertConnection(connection: IConnection, ignoreTokenErrors = false): Promise<supertest.Response> {
     return supertest
       .agent(this.app)
       .post('/connection')
+      .query({ ignoreTokenErrors })
       .set('Content-Type', 'application/json')
       .send(connection as object);
   }

--- a/packages/auth-manager/tests/unit/connection/models/connectionManager.spec.ts
+++ b/packages/auth-manager/tests/unit/connection/models/connectionManager.spec.ts
@@ -117,21 +117,18 @@ describe('ConnectionManager', () => {
       connectionRepo.manager.transaction.mockImplementation(async (fn: (a: unknown) => Promise<unknown>) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return fn({
-          withRepository: jest
-            .fn()
-            // .mockImplementation((callValue) => (callValue === connectionRepo ? connectionTransactionRepo : domainTransactionRepo)),
-            .mockImplementation((callValue) => {
-              switch (callValue) {
-                case connectionRepo:
-                  return connectionTransactionRepo;
-                case domainRepo:
-                  return domainTransactionRepo;
-                case keysRepo:
-                  return keyTransactionRepo;
-                default:
-                  throw new Error('unknown repo');
-              }
-            }),
+          withRepository: jest.fn().mockImplementation((callValue) => {
+            switch (callValue) {
+              case connectionRepo:
+                return connectionTransactionRepo;
+              case domainRepo:
+                return domainTransactionRepo;
+              case keysRepo:
+                return keyTransactionRepo;
+              default:
+                throw new Error('unknown repo');
+            }
+          }),
           getRepository: jest.fn().mockReturnValue(clientTransactionRepo),
         });
       });

--- a/packages/auth-manager/tests/unit/connection/models/connectionManager.spec.ts
+++ b/packages/auth-manager/tests/unit/connection/models/connectionManager.spec.ts
@@ -9,6 +9,7 @@ import { DomainRepository } from '../../../../src/domain/DAL/domainRepository';
 import { ConnectionSearchParams } from '../../../../src/connection/models/connection';
 import { ClientNotFoundError } from '../../../../src/client/models/errors';
 import { DomainNotFoundError } from '../../../../src/domain/models/errors';
+import { KeyRepository } from '../../../../src/key/DAL/keyRepository';
 
 describe('ConnectionManager', () => {
   let connectionManager: ConnectionManager;
@@ -18,11 +19,13 @@ describe('ConnectionManager', () => {
     transaction: jest.fn(),
   };
   const mockedDomainRepository = {};
+  const mockedKeysRepository = {};
   beforeEach(function () {
     connectionManager = new ConnectionManager(
       jsLogger({ enabled: false }),
       mockedConnectionRepository as unknown as ConnectionRepository,
-      mockedDomainRepository as DomainRepository
+      mockedDomainRepository as DomainRepository,
+      mockedKeysRepository as KeyRepository
     );
     jest.resetAllMocks();
   });
@@ -105,6 +108,7 @@ describe('ConnectionManager', () => {
       domainTransactionRepo.checkInputForNonExistingDomains.mockResolvedValue([]);
       const connectionRepo = { manager: { transaction: jest.fn() } };
       const domainRepo = {};
+      const keysRepo = {};
       connectionRepo.manager.transaction.mockImplementation(async (fn: (a: unknown) => Promise<unknown>) => {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return fn({
@@ -118,7 +122,8 @@ describe('ConnectionManager', () => {
       manager = new ConnectionManager(
         jsLogger({ enabled: false }),
         connectionRepo as unknown as ConnectionRepository,
-        domainRepo as DomainRepository
+        domainRepo as DomainRepository,
+        keysRepo as KeyRepository
       );
     });
 

--- a/packages/auth-manager/tests/utils/key.ts
+++ b/packages/auth-manager/tests/utils/key.ts
@@ -24,3 +24,29 @@ export function getMockKeys(): [JWKPrivateKey, JWKPublicKey] {
     publicKey,
   ];
 }
+
+export function getRealKeys(): [JWKPrivateKey, JWKPublicKey] {
+  const publicKey: JWKPublicKey = {
+    kty: 'RSA',
+    n: 'vxbyg6yr0Y3C5-Q4DkPoL1kluBr79usrbPABUHX9HQjqXcjAAiwvHCQqlUvAjx38sEY4FqN9RykyPNKcb_0tLvcBwf6Tdn79j9K9DPVhp0QuyP7NjqOliKpHJtftC5hHXi2Moxb7spJ3cUaIMi3YqHQr9QAP3hx1tBiRxq0R1CkMHK4cj0LAmXnzeOCuKdV09x4TfxvhlfvBYoWURUJr3EnJHUme9JAxpF6fn1jySAjcY2XOplOz2MQqIliERN1Ltmgtk91z2rUmYkZ0I4EVDKSttrcKaGLrKT69oD_BLwXdmZ5qaHnPtT1vCVgqUXxx89Cki0SIFT5bdefi5X0kNw',
+    e: 'AQAB',
+    alg: 'RS256',
+    kid: 'test',
+  };
+  return [
+    {
+      kty: 'RSA',
+      n: 'vxbyg6yr0Y3C5-Q4DkPoL1kluBr79usrbPABUHX9HQjqXcjAAiwvHCQqlUvAjx38sEY4FqN9RykyPNKcb_0tLvcBwf6Tdn79j9K9DPVhp0QuyP7NjqOliKpHJtftC5hHXi2Moxb7spJ3cUaIMi3YqHQr9QAP3hx1tBiRxq0R1CkMHK4cj0LAmXnzeOCuKdV09x4TfxvhlfvBYoWURUJr3EnJHUme9JAxpF6fn1jySAjcY2XOplOz2MQqIliERN1Ltmgtk91z2rUmYkZ0I4EVDKSttrcKaGLrKT69oD_BLwXdmZ5qaHnPtT1vCVgqUXxx89Cki0SIFT5bdefi5X0kNw',
+      e: 'AQAB',
+      d: 'M2MgZHiS3A-bUnD1AiEQ12rJ0fCvwX8Mdoc0U0bngl9bZ00NFYh8Qr0XFn8AkXwm7-ByRORCVFinweOBXjxfYjnapyimzz7nQT4SyOFUGX8kdbjP3oPziAUCjVeTz4Jr7s-g-lq75RGuPTASgCwED4juKTyTB8_vdzcEPMFeAgdv-xsD0V936GM1ZlI1Jvl11jsBndzVjtQiPydZsyHifEN0ZtJpyp9G9vGYSSyX6eaTIXbjIM0xte_jsNOZprAuBni4pTWVRgMmUOY6eP0qrlwd_DXq4P9617T43e55Y8YfdMRJnedHT2sM0ay5no7kRWrbcOW0gy65SGwtYNdkwQ',
+      p: '-dG1-KyXuDPsxFr4NtX85NNnXirvV3wxtNb56YD5MQwSVW1ZM7mO8WNQ8s_WxyMaNADpPEkHsGZ8piAPdt-CQSE2vfa3TIPMwXVxxF_SfWkCIfFea-2cmdu0Nq0TrnpUd6sq-ynqJGvZPh8njUwpoLnTErC-9X-YVpBZB2WK6nU',
+      q: 'w9FCS3KZPBwuRszrNGBM0IWL1LELXw026un_R2AQrCPqDLJHy9cNi7J2J5lm9fG1LedlYVSTrPG7snsIaACyArNO9wXgKX7CkI84ObYXWylJ0X0-BXQAIclrJLbfCfUxpEqp15CWzE7RmETOuIOD0JU5ZybaF2TpWm-ljKPIxns',
+      dp: '6hN8fTBCzN8iZ22Ri9f_qO0Iuuxh7Mg6zuZrrkYht7pG53KZFWU1sapMa-cgqOCUKcv8vnbzVG8DNqlttAWDR8F2SJKGd5Q7Y73Gxqi-UrH0xJcj0N8IUAXTmzOa8G5A_QwOLt68PDotiQ6qAbQugSH8y1N-6gsPU3TXZp3Xhw0',
+      dq: 'R4MekOszJw6rn9OqeiBJLUX4QR6_JmFvEu-N-QUOUa90BFr_eWP6YHA2UlPllCBHqJH_JkJ7BAfsIkxoT4Mhf3b4eaI9sSnH6H9Fa14ivXogqU7x3Y_1lGE4rdnTLpHLJVLXIBB_4fFO_iryy9PLydsVcaRwtWZ3Cj4H2YrfAg0',
+      qi: 'sYFXsJ8PV3gotkjNvN92O_VNjNlStYWmsQO0fF3VXNxez5l0sBikSUKnkUWbqCFEsk_oKSn1GIhOZyOTkokihoHTlVqeVrecY7HHsbftBKvNF4d_cKb-sV2zxZUW5YZhXskF54Cje9IHtEwRvuPQ50yzPCkgwXAmhTsB9gOGODA',
+      alg: 'RS256',
+      kid: 'test',
+    },
+    publicKey,
+  ];
+}


### PR DESCRIPTION
Added feature to create token automatically for connections.
When token string is empty in the request, and a private key is defined for the environment a new token will be generated.