### PR TITLE
fix(auth-cron): s3 bundle should have public-read permissions

### DIFF
--- a/example/data/policy.rego
+++ b/example/data/policy.rego
@@ -52,7 +52,11 @@ deny contains "domain missing" if {
 }
 
 deny contains "domain check failed" if {
- 	every domain in userData.domains { domain != input.domain }
+ 	every userDomain in userData.domains { 
+		every inputDomain in input.domain {
+			inputDomain != userDomain
+		}
+	 }
 }
 
 allowed_empty_origin if {

--- a/packages/auth-cron/src/s3.ts
+++ b/packages/auth-cron/src/s3.ts
@@ -61,7 +61,7 @@ class S3client {
 
     logger?.debug({ msg: 'uploading object to s3', bucket: this.bucket, key: this.key, endpoint: this.endpoint });
     // eslint-disable-next-line @typescript-eslint/naming-convention
-    const command = new PutObjectCommand({ Body: file, Bucket: this.bucket, Key: this.key, ContentType: 'application/gzip' });
+    const command = new PutObjectCommand({ Body: file, Bucket: this.bucket, ACL: 'public-read', Key: this.key, ContentType: 'application/gzip' });
 
     const res = await this.s3client.send(command);
 


### PR DESCRIPTION
| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                       |

Newly created bundle is uploaded to S3 with wrong permissions - it should have `public-read` permissions so OPA can access it.