### PR TITLE
helm: tune config offline mode on configmap

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -9,4 +9,4 @@ dependencies:
   repository: file://../packages/auth-manager/helm
   version: 1.3.0
 digest: sha256:af2b9a3d5b6da0b2539fb28333f69e22aa736bc7af4daa3becbb6ecbad21383d
-generated: "2025-02-02T12:30:08.444220666+02:00"
+generated: "2025-02-03T14:44:40.776610458+02:00"

--- a/helm/templates/postgres-secret.yaml
+++ b/helm/templates/postgres-secret.yaml
@@ -1,6 +1,6 @@
 {{- $releaseName := .Release.Name -}}
 {{- $chartName := include "opa-la.name" . -}}
-{{- if (not (.Values.dbConfig.useExternalSecret)) }}
+{{- if and .Values.enabled .Values.env.configManager.offlineMode (not (.Values.dbConfig.useExternalSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/templates/postgres-secret.yaml
+++ b/helm/templates/postgres-secret.yaml
@@ -1,6 +1,6 @@
 {{- $releaseName := .Release.Name -}}
 {{- $chartName := include "opa-la.name" . -}}
-{{- if and .Values.enabled .Values.env.configManager.offlineMode (not (.Values.dbConfig.useExternalSecret)) }}
+{{- if and .Values.offlineMode (not (.Values.dbConfig.useExternalSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -98,6 +98,13 @@ auth-cron:
   initialDelaySeconds: 60
   resetOnConfigChange: true
 
+  extraEnvVars: []
+  # extraEnvVars:
+  #   - name: DB_HOST
+  #     value: localhost
+  #   - name: DB_NAME
+  #     value: postgres
+
   cloudProvider: *cloudProvider
 
   caSecretName: *caSecretName 
@@ -163,6 +170,12 @@ auth-manager:
   initialDelaySeconds: 60
   resetOnConfigChange: true
 
+  extraEnvVars: []
+  # extraEnvVars:
+  #   - name: DB_HOST
+  #     value: localhost
+  #   - name: DB_NAME
+  #     value: postgres
   cloudProvider: *cloudProvider
 
   caSecretName: *caSecretName

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,8 @@ global:
   environment: ''
 
 environment: &environment development
+configServerUrl: &configServerUrl 'http://localhost/api'
+offlineMode: &configOfflineMode false
 
 cloudProvider: &cloudProvider
   dockerRegistryUrl: my-registry-url.io
@@ -15,20 +17,20 @@ caSecretName: &caSecretName ''
 caPath: &caPath '/usr/local/share/ca-certificates'
 caKey: &caKey 'ca.crt'
 
-dbConfig: &dbConfig
-  host: localhost
-  username: postgres
-  password: postgres
-  database: auth-manager
-  # port: 5432
-  externalSecretName: ''
-  useExternalSecret: true
-  sslAuth:
-    enabled: false
-    secretName: secret-name
-    certFileName: postgresql.crt
-    keyFileName: postgresql.key
-    caFileName: root.crt
+# dbConfig: &dbConfig
+#   host: localhost
+#   username: postgres
+#   password: postgres
+#   database: auth-manager
+#   # port: 5432
+#   externalSecretName: ''
+#   useExternalSecret: true
+#   sslAuth:
+#     enabled: false
+#     secretName: secret-name
+#     certFileName: postgresql.crt
+#     keyFileName: postgresql.key
+#     caFileName: root.crt
 
 opa:
   cloudProvider: *cloudProvider
@@ -43,9 +45,6 @@ opa:
 
   enabled: true
   replicaCount: 2
-
-  decisionLogs:
-    console: true
 
   tracing:
     enabled: false
@@ -112,22 +111,22 @@ auth-cron:
   caKey: *caKey
 
   image:
-    repository: auth-cron
-    tag: 'v0.0.0'
+    repository: infra/auth-cron
+    # tag: 'v1.3.0'
 
   env:
     logLevel: info
     logPrettyPrintEnabled: false
 
     configManager:
-      offlineMode: false
-      serverUrl: 'http://infra-config-config-server/api'
-      configName: 'auth-cron'
+      offlineMode: *configOfflineMode
+      serverUrl: *configServerUrl
+      configName: 'infra-auth-cron'
 
-  dbConfig: *dbConfig
+  # dbConfig: *dbConfig
 
-  cronConfig:
-    {}
+  # cronConfig:
+  #   {}
     # np:
     #   pattern: '* * * * * *'
     #   s3:
@@ -183,8 +182,8 @@ auth-manager:
   caKey: *caKey
 
   image:
-    repository: auth-manager
-    # tag: 'latest'
+    repository: infra/auth-manager
+    # tag: v1.3.0
 
   env:
     port: 8080
@@ -201,11 +200,11 @@ auth-manager:
       url: http://localhost:55681/v1/metrics
 
     configManager:
-      offlineMode: false
-      serverUrl: 'http://infra-config-config-server/api'
-      configName: 'auth-manager'
+      offlineMode: *configOfflineMode
+      serverUrl: *configServerUrl
+      configName: 'infra-auth-manager'
 
-  dbConfig: *dbConfig
+  # dbConfig: *dbConfig
 
   resources:
     enabled: true

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -97,6 +97,7 @@ auth-cron:
   initialDelaySeconds: 60
   resetOnConfigChange: true
 
+  additionalPodAnnotations: {}
   extraEnvVars: []
   # extraEnvVars:
   #   - name: DB_HOST
@@ -122,7 +123,7 @@ auth-cron:
       offlineMode: *configOfflineMode
       serverUrl: *configServerUrl
       configName: 'infra-auth-cron'
-
+  
   # dbConfig: *dbConfig
 
   # cronConfig:
@@ -169,6 +170,7 @@ auth-manager:
   initialDelaySeconds: 60
   resetOnConfigChange: true
 
+  additionalPodAnnotations: {}
   extraEnvVars: []
   # extraEnvVars:
   #   - name: DB_HOST

--- a/packages/auth-cron/helm/templates/configmap.yaml
+++ b/packages/auth-cron/helm/templates/configmap.yaml
@@ -5,26 +5,21 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-{{ $chartName }}-configmap
 data:
+  CONFIG_OFFLINE_MODE: {{ .Values.env.configManager.offlineMode | quote }}
+  {{- if .Values.env.configManager.offlineMode }}
   LOG_LEVEL: {{ .Values.env.logLevel | quote }}
   LOG_PRETTY_PRINT_ENABLED: {{ .Values.env.logPrettyPrintEnabled | quote }}
-  {{- with .Values.dbConfig }}
-  DB_HOST: {{ .host }}
-  DB_NAME: {{ .database }}
-  DB_PORT: {{ .port | default 5432 | quote }}
-  {{- end -}}
+  DB_HOST: {{ .Values.dbConfig.host }}
+  DB_NAME: {{ .Values.dbConfig.database }}
+  DB_PORT: {{ .Values.dbConfig.port | default 5432 | quote }}
+  DB_ENABLE_SSL_AUTH: {{ .Values.dbConfig.sslAuth.enabled | quote }}
   {{- if .Values.dbConfig.sslAuth.enabled }}
-  DB_ENABLE_SSL_AUTH: "true"
   DB_CERT_PATH: /tmp/certs/{{ .Values.dbConfig.sslAuth.certFileName }}
   DB_KEY_PATH: /tmp/certs/{{ .Values.dbConfig.sslAuth.keyFileName }}
   DB_CA_PATH: /tmp/certs/{{ .Values.dbConfig.sslAuth.caFileName }}
+  {{- end }}
   {{- else }}
-  DB_ENABLE_SSL_AUTH: "false"
-  {{- end }}
-  {{- with .Values.env.configManager }}
-  CONFIG_OFFLINE_MODE: {{ .offlineMode | quote }}
-  {{- if not .offlineMode }}
-  CONFIG_SERVER_URL: {{ .serverUrl | quote }}
-  CONFIG_NAME: {{ .configName | quote }}
-  {{- end }}
+  CONFIG_SERVER_URL: {{ .Values.env.configManager.serverUrl | quote }}
+  CONFIG_NAME: {{ .Values.env.configManager.configName | quote }}
   {{- end }}
 {{- end }}

--- a/packages/auth-cron/helm/templates/cron-secret.yaml
+++ b/packages/auth-cron/helm/templates/cron-secret.yaml
@@ -1,6 +1,6 @@
 {{- $releaseName := .Release.Name -}}
 {{- $chartName := include "auth-cron.name" . -}}
-{{- if .Values.enabled -}}
+{{- if and .Values.enabled .Values.env.configManager.offlineMode -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/packages/auth-cron/helm/templates/deployment.yaml
+++ b/packages/auth-cron/helm/templates/deployment.yaml
@@ -51,27 +51,29 @@ spec:
               name: root-ca
               subPath: {{ quote .Values.caKey }}
             {{- end }}
+            {{- if .Values.env.configManager.offlineMode }}
             - name: config
               mountPath: /usr/src/app/packages/auth-cron/config/production.json
               subPath: production.json
               readOnly: true
-              {{- if .Values.dbConfig.sslAuth.enabled }}
-              {{- if .Values.dbConfig.sslAuth.caFileKey }}
-              - name: ca-file
-                mountPath: /tmp/certs/ca.crt
-                subPath: ca.crt
-              {{- end }}
-              {{- if .Values.dbConfig.sslAuth.keyFileKey }}
-              - name: key-file
-                mountPath: /tmp/certs/key.pem
-                subPath: key.pem
-              {{- end }}
-              {{- if .Values.dbConfig.sslAuth.certFileKey }}
-              - name: cert-file
-                mountPath: /tmp/certs/cert.pem
-                subPath: cert.pem
-              {{- end }}
-              {{- end }}
+            {{- end }}
+            {{- if .Values.dbConfig.sslAuth.enabled }}
+            {{- if .Values.dbConfig.sslAuth.caFileName }}
+            - name: ca-file
+              mountPath: /tmp/certs/{{ .Values.dbConfig.sslAuth.caFileName }}
+              subPath: {{ .Values.dbConfig.sslAuth.caFileName }}
+            {{- end }}
+            {{- if .Values.dbConfig.sslAuth.keyFileName }}
+            - name: key-file
+              mountPath: /tmp/certs/{{ .Values.dbConfig.sslAuth.keyFileName }}
+              subPath: {{ .Values.dbConfig.sslAuth.keyFileName }}
+            {{- end }}
+            {{- if .Values.dbConfig.sslAuth.certFileName }}
+            - name: cert-file
+              mountPath: /tmp/certs/{{ .Values.dbConfig.sslAuth.certFileName }}
+              subPath: {{ .Values.dbConfig.sslAuth.certFileName }}
+            {{- end }}
+            {{- end }}
           env:
             {{- if .Values.env.configManager.offlineMode }}
             - name: DB_USERNAME
@@ -79,14 +81,7 @@ spec:
                 secretKeyRef:
                   name: {{ $postgresSecretName }}
                   key: username
-            {{- if .Values.dbConfig.sslAuth.enabled }}
-            - name: DB_CA_PATH
-              value: /tmp/certs/ca.crt
-            - name: DB_KEY_PATH
-              value: /tmp/certs/key.pem
-            - name: DB_CERT_PATH
-              value: /tmp/certs/cert.pem
-            {{- else }}
+            {{- if not .Values.dbConfig.sslAuth.enabled }}
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -99,6 +94,9 @@ spec:
               value: {{ printf "%s/%s" .Values.caPath .Values.caKey | quote }}
             - name: NODE_EXTRA_CA_CERTS
               value: {{ printf "%s/%s" .Values.caPath .Values.caKey | quote }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -118,36 +116,38 @@ spec:
           secret:
             secretName: {{ .Values.caSecretName }}
         {{- end }}
-        {{- if and .Values.dbConfig.sslAuth.enabled .Values.env.configManager.offlineMode }}
-        {{- if .Values.dbConfig.sslAuth.caFileKey }}
+        {{- if .Values.dbConfig.sslAuth.enabled }}
+        {{- if .Values.dbConfig.sslAuth.caFileName }}
         - name: ca-file
           secret:
             secretName: {{ $postgresSecretName }}
             items:
-              - key: {{ .Values.dbConfig.sslAuth.caFileKey }}
+              - key: {{ .Values.dbConfig.sslAuth.caFileName }}
                 path: ca.crt
         {{- end }}
-        {{- if .Values.dbConfig.sslAuth.keyFileKey }}
+        {{- if .Values.dbConfig.sslAuth.keyFileName }}
         - name: key-file
           secret:
             secretName: {{ $postgresSecretName }}
             items:
-              - key: {{ .Values.dbConfig.sslAuth.keyFileKey }}
+              - key: {{ .Values.dbConfig.sslAuth.keyFileName }}
                 path: key.pem
         {{- end }}
-        {{- if .Values.dbConfig.sslAuth.certFileKey }}
+        {{- if .Values.dbConfig.sslAuth.certFileName }}
         - name: cert-file
           secret:
             secretName: {{ $postgresSecretName }}
             items:
-              - key: {{ .Values.dbConfig.sslAuth.certFileKey }}
+              - key: {{ .Values.dbConfig.sslAuth.certFileName }}
                 path: cert.pem
         {{- end }}
         {{- end }}
+        {{- if .Values.env.configManager.offlineMode }}
         - name: config
           secret:
             secretName: {{ $releaseName }}-{{ $chartName }}-cron-secret
             items:
             - key: config
               path: production.json
+        {{- end }}
 {{- end -}}

--- a/packages/auth-cron/helm/templates/deployment.yaml
+++ b/packages/auth-cron/helm/templates/deployment.yaml
@@ -34,6 +34,9 @@ spec:
       {{- if .Values.resetOnConfigChange }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.additionalPodAnnotations }}
+        {{- toYaml .Values.additionalPodAnnotations | nindent 8}}
+        {{- end }}
       {{- end }}
     spec:
     {{- if $cloudProviderImagePullSecretName }}

--- a/packages/auth-cron/helm/values.yaml
+++ b/packages/auth-cron/helm/values.yaml
@@ -40,6 +40,8 @@ env:
     serverUrl: 'http://infra-config-config-server/api'
     configName: 'auth-cron'
 
+additionalPodAnnotations: {}
+
 dbConfig:
   host: localhost
   username: postgres

--- a/packages/auth-cron/helm/values.yaml
+++ b/packages/auth-cron/helm/values.yaml
@@ -49,7 +49,7 @@ dbConfig:
   externalSecretName: ''
   useExternalSecret: false  
   sslAuth:
-    enabled: true
+    enabled: false
     secretName: secret-name
     certFileName: cert.pem
     keyFileName: key.pem

--- a/packages/auth-cron/helm/values.yaml
+++ b/packages/auth-cron/helm/values.yaml
@@ -11,6 +11,13 @@ initialDelaySeconds: 60
 nodePort: 30030 #for minikube deployment only
 resetOnConfigChange: true
 
+extraEnvVars: []
+# extraEnvVars:
+#   - name: DB_HOST
+#     value: localhost
+#   - name: DB_NAME
+#     value: postgres
+
 cloudProvider:
   dockerRegistryUrl: my-registry-url.io
   imagePullSecretName: 'my-registry-secret'
@@ -42,11 +49,11 @@ dbConfig:
   externalSecretName: ''
   useExternalSecret: false  
   sslAuth:
-    enabled: false
+    enabled: true
     secretName: secret-name
-    certFileName: certFile
-    keyFileName: keyFile
-    caFileName: caFile
+    certFileName: cert.pem
+    keyFileName: key.pem
+    caFileName: ca.crt
 
 cronConfig:
   {}

--- a/packages/auth-manager/helm/templates/configmap.yaml
+++ b/packages/auth-manager/helm/templates/configmap.yaml
@@ -7,6 +7,8 @@ kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-{{ $chartName }}-configmap
 data:
+  CONFIG_OFFLINE_MODE: {{ .Values.env.configManager.offlineMode | quote }}
+  {{- if .Values.env.configManager.offlineMode }}
   REQUEST_PAYLOAD_LIMIT: {{ .Values.env.requestPayloadLimit | quote }}
   RESPONSE_COMPRESSION_ENABLED: {{ .Values.env.responseCompressionEnabled | quote }}
   LOG_LEVEL: {{ .Values.env.logLevel | quote }}
@@ -19,21 +21,17 @@ data:
   TELEMETRY_METRICS_ENABLED: 'true'
   TELEMETRY_METRICS_URL: {{ $metricsUrl }}
   {{ end }}
-  {{- with .Values.dbConfig }}
-  DB_HOST: {{ .host }}
-  DB_NAME: {{ .database }}
-  DB_PORT: {{ .port | default 5432 | quote }}
-  {{- end -}}
+  DB_HOST: {{ .Values.dbConfig.host }}
+  DB_NAME: {{ .Values.dbConfig.database }}
+  DB_PORT: {{ .Values.dbConfig.port | default 5432 | quote }}
+  DB_ENABLE_SSL_AUTH: {{ .Values.dbConfig.sslAuth.enabled | quote }}
   {{- if .Values.dbConfig.sslAuth.enabled }}
-  DB_ENABLE_SSL_AUTH: "true"
+  DB_CERT_PATH: /tmp/certs/{{ .Values.dbConfig.sslAuth.certFileName }}
+  DB_KEY_PATH: /tmp/certs/{{ .Values.dbConfig.sslAuth.keyFileName }}
+  DB_CA_PATH: /tmp/certs/{{ .Values.dbConfig.sslAuth.caFileName }}
+  {{- end }}
   {{- else }}
-  DB_ENABLE_SSL_AUTH: "false"
-  {{- end }}
-  {{- with .Values.env.configManager }}
-  CONFIG_OFFLINE_MODE: {{ .offlineMode | quote }}
-  {{- if not .offlineMode }}
-  CONFIG_SERVER_URL: {{ .serverUrl | quote }}
-  CONFIG_NAME: {{ .configName | quote }}
-  {{- end }}
+  CONFIG_SERVER_URL: {{ .Values.env.configManager.serverUrl | quote }}
+  CONFIG_NAME: {{ .Values.env.configManager.configName | quote }}
   {{- end }}
 {{- end }}

--- a/packages/auth-manager/helm/templates/deployment.yaml
+++ b/packages/auth-manager/helm/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- if .Values.resetOnConfigChange }}
       annotations:
         checksum/configmap: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.additionalPodAnnotations }}
+        {{- toYaml .Values.additionalPodAnnotations | nindent 8}}
+        {{- end }}
       {{- end }}
     spec:
     {{- if $cloudProviderImagePullSecretName }}

--- a/packages/auth-manager/helm/templates/deployment.yaml
+++ b/packages/auth-manager/helm/templates/deployment.yaml
@@ -53,18 +53,18 @@ spec:
             {{- if .Values.dbConfig.sslAuth.enabled }}
             {{- if .Values.dbConfig.sslAuth.caFileKey }}
             - name: ca-file
-              mountPath: /tmp/certs/ca.crt
-              subPath: ca.crt
+              mountPath: /tmp/certs/{{ .Values.dbConfig.sslAuth.caFileName }}
+              subPath: {{ .Values.dbConfig.sslAuth.caFileName }}
             {{- end }}
             {{- if .Values.dbConfig.sslAuth.keyFileKey }}
             - name: key-file
-              mountPath: /tmp/certs/key.pem
-              subPath: key.pem
+              mountPath: /tmp/certs/{{ .Values.dbConfig.sslAuth.keyFileName }}
+              subPath: {{ .Values.dbConfig.sslAuth.keyFileName }}
             {{- end }}
             {{- if .Values.dbConfig.sslAuth.certFileKey }}
             - name: cert-file
-              mountPath: /tmp/certs/cert.pem
-              subPath: cert.pem
+              mountPath: /tmp/certs/{{ .Values.dbConfig.sslAuth.certFileName }}
+              subPath: {{ .Values.dbConfig.sslAuth.certFileName }}
             {{- end }}
             {{- end }}            
           env:
@@ -74,14 +74,7 @@ spec:
                 secretKeyRef:
                   name: {{ $postgresSecretName }}
                   key: username
-            {{- if .Values.dbConfig.sslAuth.enabled }}
-            - name: DB_CA_PATH
-              value: /tmp/certs/ca.crt
-            - name: DB_KEY_PATH
-              value: /tmp/certs/key.pem
-            - name: DB_CERT_PATH
-              value: /tmp/certs/cert.pem
-            {{- else }}                  
+            {{- if not .Values.dbConfig.sslAuth.enabled }}               
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
@@ -96,6 +89,9 @@ spec:
               value: {{ printf "%s/%s" .Values.caPath .Values.caKey | quote }}
             - name: NODE_EXTRA_CA_CERTS
               value: {{ printf "%s/%s" .Values.caPath .Values.caKey | quote }}
+            {{- end }}
+            {{- if .Values.extraEnvVars }}
+            {{- toYaml .Values.extraEnvVars | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:
@@ -119,29 +115,29 @@ spec:
           secret:
             secretName: {{ .Values.caSecretName }}
         {{- end }}
-        {{- if and .Values.dbConfig.sslAuth.enabled .Values.env.configManager.offlineMode }}
-        {{- if .Values.dbConfig.sslAuth.caFileKey }}
+        {{- if .Values.dbConfig.sslAuth.enabled }}
+        {{- if .Values.dbConfig.sslAuth.caFileName }}
         - name: ca-file
           secret:
             secretName: {{ $postgresSecretName }}
             items:
-              - key: {{ .Values.dbConfig.sslAuth.caFileKey }}
+              - key: {{ .Values.dbConfig.sslAuth.caFileName }}
                 path: ca.crt
         {{- end }}
-        {{- if .Values.dbConfig.sslAuth.keyFileKey }}
+        {{- if .Values.dbConfig.sslAuth.keyFileName }}
         - name: key-file
           secret:
             secretName: {{ $postgresSecretName }}
             items:
-              - key: {{ .Values.dbConfig.sslAuth.keyFileKey }}
+              - key: {{ .Values.dbConfig.sslAuth.keyFileName }}
                 path: key.pem
         {{- end }}
-        {{- if .Values.dbConfig.sslAuth.certFileKey }}
+        {{- if .Values.dbConfig.sslAuth.certFileName }}
         - name: cert-file
           secret:
             secretName: {{ $postgresSecretName }}
             items:
-              - key: {{ .Values.dbConfig.sslAuth.certFileKey }}
+              - key: {{ .Values.dbConfig.sslAuth.certFileName }}
                 path: cert.pem
         {{- end }}
         {{- end }}        

--- a/packages/auth-manager/helm/values.yaml
+++ b/packages/auth-manager/helm/values.yaml
@@ -10,6 +10,13 @@ replicaCount: 1
 initialDelaySeconds: 60
 resetOnConfigChange: true
 
+extraEnvVars: []
+# extraEnvVars:
+#   - name: DB_HOST
+#     value: localhost
+#   - name: DB_NAME
+#     value: postgres
+
 cloudProvider:
   dockerRegistryUrl: my-registry-url.io
   imagePullSecretName: 'my-registry-secret'
@@ -53,9 +60,9 @@ dbConfig:
   sslAuth:
     enabled: false
     secretName: secret-name
-    certFileName: certFile
-    keyFileName: keyFile
-    caFileName: caFile
+    certFileName: cert.pem
+    keyFileName: key.pem
+    caFileName: ca.crt
 
 resources:
   enabled: true

--- a/packages/auth-manager/helm/values.yaml
+++ b/packages/auth-manager/helm/values.yaml
@@ -64,6 +64,8 @@ dbConfig:
     keyFileName: key.pem
     caFileName: ca.crt
 
+additionalPodAnnotations: {}
+
 resources:
   enabled: true
   value:


### PR DESCRIPTION
ConfigMap should take env values only if config manager configured to "false".
 
also made modifications on deployment.yaml 

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                      |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |
