### PR TITLE
helm: add labels to pods

### DIFF
--- a/helm/Chart.lock
+++ b/helm/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: opa
   repository: file://charts/opa
-  version: 1.4.0
+  version: 1.5.0
 - name: auth-cron
   repository: file://../packages/auth-cron/helm
-  version: 1.4.0
+  version: 1.5.0
 - name: auth-manager
   repository: file://../packages/auth-manager/helm
-  version: 1.4.0
+  version: 1.5.0
 - name: auth-ui
   repository: file://../packages/auth-ui/helm
-  version: 1.4.0
-digest: sha256:8d620d61ed3ff50dddcfc08bb5e88b9b891337453cb7cfc52790816631e3df7d
-generated: "2025-07-01T11:21:33.59824+03:00"
+  version: 1.5.0
+digest: sha256:1dea9e9fa7650c8e3abd5a4fd892e32ceee2da17fb542ff88477465721c7f037
+generated: "2025-07-03T13:21:44.385507648+03:00"

--- a/helm/charts/opa/templates/deployment.yaml
+++ b/helm/charts/opa/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         app: {{ $chartName }}
         release: {{ $releaseName }}
         run: {{ $releaseName }}-{{ $chartName }}
-        {{- include "opa.selectorLabels" . | nindent 8 }}
+        {{- include "opa.labels" . | nindent 8 }}
       annotations:
         {{ include "mc-labels-and-annotations.annotations" . | nindent 8 }}
         {{- if .Values.resetOnConfigChange }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -163,8 +163,8 @@ auth-ui:
 
   config: |
     {
-      "8080": {
-        "name": "Infra Dev Auth Manager",
+      "Local": {
+        "name": "localhost",
         "url": "https://infra-opala-auth-manager",
         "envs": [
           {

--- a/packages/auth-cron/helm/templates/deployment.yaml
+++ b/packages/auth-cron/helm/templates/deployment.yaml
@@ -29,7 +29,7 @@ spec:
         app: {{ $chartName }}
         release: {{ $releaseName }}
         run: {{ $releaseName }}-{{ $chartName }}
-        {{- include "auth-cron.selectorLabels" . | nindent 8 }}
+        {{- include "auth-cron.labels" . | nindent 8 }}
       {{- if .Values.resetOnConfigChange }}
       annotations:
         {{ include "mc-labels-and-annotations.annotations" . | nindent 8 }}

--- a/packages/auth-manager/helm/templates/deployment.yaml
+++ b/packages/auth-manager/helm/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         app: {{ $chartName }}
         release: {{ $releaseName }}
         run: {{ $releaseName }}-{{ $chartName }}
-        {{- include "auth-manager.selectorLabels" . | nindent 8 }}
+        {{- include "auth-manager.labels" . | nindent 8 }}
       {{- if .Values.resetOnConfigChange }}
       annotations:
         {{ include "mc-labels-and-annotations.annotations" . | nindent 8 }}

--- a/packages/auth-ui/helm/templates/deployment.yaml
+++ b/packages/auth-ui/helm/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         app: {{ $chartName }}
         release: {{ $releaseName }}
         run: {{ $releaseName }}-{{ $chartName }}
-        {{- include "auth-ui.selectorLabels" . | nindent 8 }}
+        {{- include "auth-ui.labels" . | nindent 8 }}
       {{- if .Values.resetOnConfigChange }}
       annotations:
         {{ include "mc-labels-and-annotations.annotations" . | nindent 8 }}


### PR DESCRIPTION
Update Helm chart configurations to include labels for various pods, enhancing organization and management. Additionally, bump the version of dependencies to 1.5.0.