### PR TITLE
helm: add pod labels

### DIFF
--- a/helm/charts/opa/templates/deployment.yaml
+++ b/helm/charts/opa/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         release: {{ $releaseName }}
         run: {{ $releaseName }}-{{ $chartName }}
         {{- include "opa.labels" . | nindent 8 }}
+        {{- if .Values.podLabels }}
+        {{- toYaml .Values.podLabels | nindent 8}}
+        {{- end }}
       annotations:
         {{ include "mc-labels-and-annotations.annotations" . | nindent 8 }}
         {{- if .Values.resetOnConfigChange }}

--- a/helm/charts/opa/values.yaml
+++ b/helm/charts/opa/values.yaml
@@ -3,6 +3,8 @@ global:
   tracing: {}
   metrics: {}
 
+podLabels: {}
+
 mcLabelsAndAnnotations:
   component: infrastructure
   owner: infra


### PR DESCRIPTION
Introduce the ability to specify custom pod labels in the Helm chart, enhancing flexibility for deployments.