### PR TITLE
deps(opa): upgrade opa from 1.0.1 to 1.7.1 MAPCO-7959

### DIFF
--- a/helm/charts/opa/Chart.yaml
+++ b/helm/charts/opa/Chart.yaml
@@ -3,7 +3,7 @@ name: opa
 description: A Helm chart for opa
 type: application
 version: 1.9.0
-appVersion: 1.0.1
+appVersion: 1.7.1
 dependencies:
   - name: mc-labels-and-annotations
     version: 0.7.0

--- a/helm/charts/opa/values.yaml
+++ b/helm/charts/opa/values.yaml
@@ -53,7 +53,7 @@ decisionLogs:
 
 tracing:
   enabled: false
-  type: grpc
+  type: http
   endpoint: localhost:4317
   # samplePercentage: 1 # Default is 100%
 

--- a/packages/auth-cron/Dockerfile
+++ b/packages/auth-cron/Dockerfile
@@ -18,7 +18,7 @@ FROM node:20.19.1-alpine3.21 as production
 ARG package=auth-cron
 
 RUN apk add dumb-init && \
-    wget -O /usr/bin/opa https://openpolicyagent.org/downloads/v1.0.1/opa_linux_amd64_static && \
+    wget -O /usr/bin/opa https://openpolicyagent.org/downloads/v1.7.1/opa_linux_amd64_static && \
     chmod a+x /usr/bin/opa
 
 ENV NODE_ENV=production


### PR DESCRIPTION
Upgrade the OPA dependency to version 1.7.1 and change the tracing type from gRPC to HTTP. Update the Dockerfile to download the new version of OPA.
The changelog can be found [here](https://github.com/open-policy-agent/opa/releases)