### PR TITLE
fix(token-kiosk): quote NODE_EXTRA_CA_CERTS value in deployment.yaml MAPCO-10453

### DIFF
--- a/apps/token-kiosk/helm/templates/deployment.yaml
+++ b/apps/token-kiosk/helm/templates/deployment.yaml
@@ -93,7 +93,7 @@ spec:
             - name: REQUESTS_CA_BUNDLE
               value: {{ printf "%s/%s" .Values.ca.path .Values.ca.key | quote }}
             - name: NODE_EXTRA_CA_CERTS
-              value: {{ printf "%s/%s" .Values.ca.path .Values.ca.key }}
+              value: {{ printf "%s/%s" .Values.ca.path .Values.ca.key | quote }}
             {{- end }}
             {{- if .Values.extraEnvVars }}
             {{- toYaml .Values.extraEnvVars | nindent 12 }}


### PR DESCRIPTION
| Question        | Answer |
| --------------- | ------ |
| Bug fix         | ✔    |
| New feature     | ✖    |
| Breaking change | ✖    |
| Deprecations    | ✖    |
| Documentation   | ✖    |
| Tests added     | ✖    |
| Chore           | ✖    |

Related issues: 

Further information:
Quoting the `NODE_EXTRA_CA_CERTS` value in the deployment configuration ensures proper handling of the certificate path.

